### PR TITLE
Update "main" in package.json to point to minified version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bugs": {
         "url": "https://github.com/KingSora/OverlayScrollbars/issues"
     },
-    "main": "js/OverlayScrollbars.js",
+    "main": "js/OverlayScrollbars.min.js",
     "scripts": {
         "build": "node build.js",
         "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Update "main" in package.json to point to minified version.

I was analyzing our production bundle and noticed that package.json is pointing towards the unminified version of the library (~360Kb) instead of the minified `js/OverlayScrollbars.min.js` (56Kb)

![image](https://user-images.githubusercontent.com/2373958/90526197-637dd880-e170-11ea-9004-43caa39b7560.png)
